### PR TITLE
Python courses wrapper

### DIFF
--- a/wrappers/PHP/ODCU-facilities.php
+++ b/wrappers/PHP/ODCU-facilities.php
@@ -1,0 +1,97 @@
+<?php
+
+class ODCU_facilities{
+
+    private $userName = "YOUR USERID";
+    private $password = "YOUR KEY";
+    private $baseURL = "https://opendata.concordia.ca/API/v1/facilities/";
+
+    function query($url){
+        $curl = curl_init();
+
+        curl_setopt_array($curl, array(
+        CURLOPT_URL => $url,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_ENCODING => "",
+        CURLOPT_MAXREDIRS => 10,
+        CURLOPT_TIMEOUT => 30,
+        CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+        CURLOPT_CUSTOMREQUEST => "GET",
+        CURLOPT_SSL_VERIFYHOST => 0,
+        CURLOPT_SSL_VERIFYPEER => 0,
+        CURLOPT_HEADER => 0,
+        CURLOPT_USERPWD => $this->userName . ":" . $this->password
+       
+       
+        ));
+
+        $response = curl_exec($curl);
+        $err = curl_error($curl);
+
+        curl_close($curl);
+
+        if ($err) {
+            var_dump($err);
+            return false;
+        } else {
+            return $response;
+        }
+    } //function query(){
+    
+    function getPointList(){
+        $url = $this->baseURL."pointlist/";
+        $result = $this->query($url);
+        return $result;
+    }
+
+    function environmental($start, $end){
+        if($start != '' and $end != ''){
+            $url = $this->baseURL."environmental/filter/$start/$end";
+        }else{
+            $url = $this->baseURL."environmental/filter/".date("Y-m-d 00:00:00")."/".date("Y-m-d H:i:s");
+        }
+        $result = $this->query($url);
+        return $result;
+    }
+
+    function consumption($start, $end){
+        if($start != '' and $end != ''){
+            $url = $this->baseURL."consumption/filter/$start/$end";
+        }else{
+            $url = $this->baseURL."consumption/filter/".date("Y-m-d 00:00:00")."/".date("Y-m-d H:i:s");
+        }
+        $result = $this->query($url);
+        return $result;
+    }
+
+}
+
+
+//make the class available in javacript
+if(isset($_GET['action'])){
+
+    $endpoint = new ODCU_facilities();
+    switch ($_GET['action']){
+        case 'pointlist':
+            echo $endpoint->getPointList();
+            break;
+
+        case 'environmental':           
+            if(isset($_GET['start']) and isset($_GET['end']) )
+                // TIME must be properly formated YYYY-MM-DD HH:MM:SS no verification made here  
+                echo $endpoint->environmental($_GET['start'], $_GET['end']);
+            else
+                echo $endpoint->environmental('', '');
+            break;
+
+        case 'consumption':           
+            if(isset($_GET['start']) and isset($_GET['end']) )
+                // TIME must be properly formated YYYY-MM-DD HH:MM:SS no verification made here  
+                echo $endpoint->consumption($_GET['start'], $_GET['end']);
+            else
+                echo $endpoint->consumption('', '');
+            break;
+    }
+}
+
+?>

--- a/wrappers/PHP/ODCU-facilities.php
+++ b/wrappers/PHP/ODCU-facilities.php
@@ -45,25 +45,21 @@ class ODCU_facilities{
     }
 
     function environmental($start, $end){
-        if($start != '' and $end != ''){
-            $start = str_replace(" ", "%20", $start);
-            $end = str_replace(" ", "%20", $end);
-            $url = $this->baseURL."environmental/filter/$start/$end";
-        }else{
-            $url = $this->baseURL."environmental/filter/".date("Y-m-d%2000:00:00")."/".date("Y-m-d%20H:i:s");
-        }
+        // ensure spaces are changed to %20 to prevent error 400
+        $start = ($start == '' ? date("Y-m-d%2000:00:00") : str_replace(" ", "%20", $start));
+        $end = ($end == '' ? date("Y-m-d%20H:i:s") : str_replace(" ", "%20", $end));
+        
+        $url = $this->baseURL."consumption/filter/$start/$end";    
         $result = $this->query($url);
         return $result;
     }
 
     function consumption($start, $end){
-        if($start != '' and $end != ''){
-            $start = str_replace(" ", "%20", $start);
-            $end = str_replace(" ", "%20", $end);
-            $url = $this->baseURL."consumption/filter/$start/$end";
-        }else{
-            $url = $this->baseURL."consumption/filter/".date("Y-m-d%2000:00:00")."/".date("Y-m-d%20H:i:s");
-        }
+        // ensure spaces are changed to %20 to prevent error 400
+        $start = ($start == '' ? date("Y-m-d%2000:00:00") : str_replace(" ", "%20", $start));
+        $end = ($end == '' ? date("Y-m-d%20H:i:s") : str_replace(" ", "%20", $end));
+        
+        $url = $this->baseURL."consumption/filter/$start/$end";    
         $result = $this->query($url);
         return $result;
     }
@@ -80,20 +76,19 @@ if(isset($_GET['action'])){
             echo $endpoint->getPointList();
             break;
 
-        case 'environmental':           
-            if(isset($_GET['start']) and isset($_GET['end']) )
-                // TIME must be properly formated YYYY-MM-DD HH:MM:SS no verification made here  
-                echo $endpoint->environmental($_GET['start'], $_GET['end']);
-            else
-                echo $endpoint->environmental('', '');
+        case 'environmental':
+            // TIME must be properly formated YYYY-MM-DD HH:MM:SS no verification made here  
+            $startTime = (isset($_GET['start']) ? $_GET['start'] : '');        
+            $endTime = (isset($_GET['end']) ? $_GET['end'] : '');
+            echo $endpoint->environmental($startTime, $endTime);
             break;
 
         case 'consumption':           
-            if(isset($_GET['start']) and isset($_GET['end']) )
-                // TIME must be properly formated YYYY-MM-DD HH:MM:SS no verification made here  
-                echo $endpoint->consumption($_GET['start'], $_GET['end']);
-            else
-                echo $endpoint->consumption('', '');
+            // TIME must be properly formated YYYY-MM-DD HH:MM:SS no verification made here  
+            $startTime = (isset($_GET['start']) ? $_GET['start'] : '');
+            $endTime = (isset($_GET['end']) ? $_GET['end'] : '');
+
+            echo $endpoint->consumption($startTime, $endTime);
             break;
     }
 }

--- a/wrappers/PHP/ODCU-facilities.php
+++ b/wrappers/PHP/ODCU-facilities.php
@@ -46,9 +46,11 @@ class ODCU_facilities{
 
     function environmental($start, $end){
         if($start != '' and $end != ''){
+            $start = str_replace(" ", "%20", $start);
+            $end = str_replace(" ", "%20", $end);
             $url = $this->baseURL."environmental/filter/$start/$end";
         }else{
-            $url = $this->baseURL."environmental/filter/".date("Y-m-d 00:00:00")."/".date("Y-m-d H:i:s");
+            $url = $this->baseURL."environmental/filter/".date("Y-m-d%2000:00:00")."/".date("Y-m-d%20H:i:s");
         }
         $result = $this->query($url);
         return $result;
@@ -56,9 +58,11 @@ class ODCU_facilities{
 
     function consumption($start, $end){
         if($start != '' and $end != ''){
+            $start = str_replace(" ", "%20", $start);
+            $end = str_replace(" ", "%20", $end);
             $url = $this->baseURL."consumption/filter/$start/$end";
         }else{
-            $url = $this->baseURL."consumption/filter/".date("Y-m-d 00:00:00")."/".date("Y-m-d H:i:s");
+            $url = $this->baseURL."consumption/filter/".date("Y-m-d%2000:00:00")."/".date("Y-m-d%20H:i:s");
         }
         $result = $this->query($url);
         return $result;

--- a/wrappers/Python/ODCU-courses.py
+++ b/wrappers/Python/ODCU-courses.py
@@ -1,0 +1,55 @@
+import urllib.request
+
+user = 'YOUR USERID'
+key = 'YOUR KEY'
+
+endpoints = {
+    'description': ['course_id'],
+    'catalog': ['subject', 'catalog', 'career'],
+    'section': ['subject', 'catalog'],
+    'schedule': ['course_id', 'subject', 'catalog'],
+    'session': ['career', 'term', 'session'],
+    'faculty': ['faculty', 'department'],
+}
+
+
+def openConnection(username, password):
+    '''Set up authentication and open connection'''
+    API_url = "https://opendata.concordia.ca"
+    password_mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+    password_mgr.add_password(None, API_url, username, password)
+    handler = urllib.request.HTTPBasicAuthHandler(password_mgr)
+    opener = urllib.request.build_opener(handler)
+    opener.open(API_url)
+    urllib.request.install_opener(opener)
+
+
+def validateRequest(endpoint, params):
+    '''Validate that a valid argument with the correct number of parameters has been supplied.'''
+    if endpoint not in endpoints:
+        helpInfo = ', '.join(endpoints.keys())
+        print(f'Invalid endpoint. Please use one of the following: {helpInfo}')
+        return False
+    elif len(params) != len(endpoints[endpoint]):
+        helpInfo = ', '.join(endpoints[endpoint])
+        print(f'Invalid params. {endpoint} requires the following: {helpInfo}')
+    else:
+        return True
+
+
+def makeRequest(endpoint, *args):
+    '''Make request and return the response after validation'''
+    if validateRequest(endpoint, args):
+        params = '/'.join(args)
+        url = f'https://opendata.concordia.ca/API/v1/course/{endpoint}/filter/{params}'
+        with urllib.request.urlopen(url) as req:
+            res = req.read()
+        return res
+    else:
+        return False
+
+
+if __name__ == "__main__":
+    openConnection(user, key)
+    response = makeRequest('session', '*', '*', '*')
+    print(response)


### PR DESCRIPTION
I made a python courses wrapper. A few notes:
* I intentionally made extensible: Just add any new endpoints to the dictionary at the top, it will always work regardless of arguments.
* I also added informative help messages for invalid requests
* There's some extra diffs. I forgot to switch to a new branch and just made a new one before making the PR. They'll disappear if the PHP facilities PR is merged before reviewing this one

One issue is that in its current state it's only python3 compatible due its usage of `urllib`, the newer `print` syntax, and f-strings. I can see how this could be an issue. Let me know if you'd like me to make it backwards compatible.