### PR TITLE
Adding new ScheduleTerm endpoint documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Daily course data export from the Student Information System (SIS) system.
 * [/course/sessions](v1/courses/sessions.md)
 * [/course/faculty](v1/courses/faculty.md)
 * [/course/experiential_learning](v1/courses/experiential_learning.md)
+* [/course/scheduleTerm/filter](v1/courses/scheduleTerm.md)
 
 ### Facilities
 Daily and historical environmental and consumption data obtained from sensors and meters located on both campuses.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Daily course data export from the Student Information System (SIS) system.
 * [/course/sessions](v1/courses/sessions.md)
 * [/course/faculty](v1/courses/faculty.md)
 * [/course/experiential_learning](v1/courses/experiential_learning.md)
-* [/course/scheduleTerm/filter](v1/courses/scheduleTerm.md)
+* [/course/scheduleTerm](v1/courses/scheduleTerm.md)
 
 ### Facilities
 Daily and historical environmental and consumption data obtained from sensors and meters located on both campuses.

--- a/v1/courses/scheduleTerm.md
+++ b/v1/courses/scheduleTerm.md
@@ -1,0 +1,127 @@
+### [Home](../../README.md) > Courses > Schedule Term
+
+# Course Sessions
+
+
+## Description
+Endpoint to request courses in a given semester.
+
+Returns all the same data from [course schedule](https://github.com/opendataConcordiaU/documentation/blob/master/v1/courses/schedule.md).
+
+
+**Data Steward:** Enrolment Services
+
+**Update Frequency:** Daily
+
+## Call
+GET course/scheduleTerm/filter/{subject}/{termcode}
+
+### Parameters
+All parameters can by substituted by a wildcard *.
+<table>
+    <tr>
+        <td><b>Parameter</b></td>
+        <td><b>Description</b></td>
+    </tr>
+    <tr>
+        <td>subject</td>
+        <td>4 character subject code (e.g. ENGL, HIST, COMM).</td>
+    </tr>
+    <tr>
+        <td>termcode</td>
+        <td>4 Digit term code.  This is comprised of the 1st, 3rd and 4th digit of the academic year and ends with one of the following :<br><br>
+1 – Summer <br>
+2 – Fall<br>
+3 – Fall/Winter<br>
+4 – Winter <br>
+5 – Spring (for CCCE career only)<br>
+6 – Summer (for CCCE career only)<br><br>
+For example, the code for Fall 2018 = 2182
+And the code for Winter 2019 = 2184 (this is because Winter 2019 comes under the 2018 academic year).</td>
+    </tr>
+</table>
+
+### Example(s)
+*Obtain all BIOL classes for winter 2023*
+
+[https://opendata.concordia.ca/API/v1/course/session/filter/BIOL/2224](https://opendata.concordia.ca/API/v1/course/scheduleTerm/filter/BIOL/2242)
+
+## Response
+<table>
+    <tr>
+        <td><b>Field Name</b></td>
+        <td><b>Type</b></td>
+        <td><b>Value Description</b></td>
+    </tr>
+    <tr>
+        <td>career</td>
+        <td>string</td>
+        <td>Undergraduate (UGRD), Graduate (GRAD) or Continuing Education (CCCE) or Professional Development (PDEV).</td>
+    </tr>
+        <tr>
+        <td>termCode</td>
+        <td></td>
+        <td>4 Digit term code.  This is comprised of the 1st, 3rd and 4th digit of the academic year and ends with one of the following :<br><br>
+1 – Summer <br>
+2 – Fall<br>
+3 – Fall/Winter<br>
+4 – Winter <br>
+5 – Spring (for CCCE career only)<br>
+6 – Summer (for CCCE career only)<br><br>
+For example, the code for Fall 2018 = 2182
+And the code for Winter 2019 = 2184 (this is because Winter 2019 comes under the 2018 academic year).</td>
+    </tr>
+        <tr>
+        <td>termDescription</td>
+        <td>string</td>
+        <td>Description of the Term Code (for e.g. Fall 2018).</td>
+    </tr>
+        <tr>
+        <td>sessionCode</td>
+        <td>string</td>
+        <td>A term can be broken down into separate sessions.  For example, a summer term will commonly have a 1st session (6H1), a second session (6H2) and a full summer session (13W).</td>
+    </tr>
+        <tr>
+        <td>sessionDescription</td>
+        <td>string</td>
+        <td>Description of the Session Code (for e.g 13 week).</td>
+    </tr>
+        <tr>
+        <td>sessionBeginDate</td>
+        <td>date</td>
+        <td>Date session begins.</td>
+    </tr>
+        <tr>
+        <td>sessionEndDate</td>
+        <td>date</td>
+        <td>Date session ends.</td>
+    </tr>
+</table>
+
+## Output
+```JSON
+[
+    {
+        "career": "GRAD",
+        "termCode": "2141",
+        "termDescription": "Summer 2014",
+        "sessionCode": "13W",
+        "sessionDescription": "13 week",
+        "sessionBeginDate": "07/05/2014",
+        "sessionEndDate": "19/08/2014"
+    },
+    {
+        "career": "GRAD",
+        "termCode": "2142",
+        "termDescription": "Fall 2014",
+        "sessionCode": "13W",
+        "sessionDescription": "13 week",
+        "sessionBeginDate": "02/09/2014",
+        "sessionEndDate": "01/12/2014"
+    },
+    ...
+]
+```
+
+## Raw Data
+https://opendata.concordia.ca/datasets/sis/CU_SR_OPEN_DATA_TERM_SESS.csv

--- a/v1/courses/scheduleTerm.md
+++ b/v1/courses/scheduleTerm.md
@@ -4,7 +4,7 @@
 
 
 ## Description
-Endpoint to request courses in a given semester.
+Endpoint to filter courses for a given semester.
 
 Returns all the same data from [course schedule](https://github.com/opendataConcordiaU/documentation/blob/master/v1/courses/schedule.md).
 
@@ -44,57 +44,244 @@ And the code for Winter 2019 = 2184 (this is because Winter 2019 comes under the
 ### Example(s)
 *Obtain all BIOL classes for winter 2023*
 
-[https://opendata.concordia.ca/API/v1/course/session/filter/BIOL/2224](https://opendata.concordia.ca/API/v1/course/scheduleTerm/filter/BIOL/2242)
+[https://opendata.concordia.ca/API/v1/course/scheduleTerm/filter/BIOL/2224](https://opendata.concordia.ca/API/v1/course/scheduleTerm/filter/BIOL/2224)
 
 ## Response
 <table>
     <tr>
         <td><b>Field Name</b></td>
         <td><b>Type</b></td>
-        <td><b>Value Description</b></td>
+        <td><b>Value Description.</b></td>
+    </tr>
+    <tr>
+        <td>courseID</td>
+        <td>integer</td>
+        <td>6 digit Course Identification Number.</td>
+    </tr>
+    <tr>
+        <td>termCode</td>
+        <td>integer</td>
+        <td>4 Digit term code.  This is comprised of the 1st, 3rd and 4th digit of the academic year and ends with one of the following : <br><br>
+         1 – Summer <br>
+         2 – Fall <br>
+         3 – Fall/Winter <br>
+         4 – Winter  <br>
+         5 – Spring (for CCCE career only) <br>
+         6 – Summer (for CCCE career only) <br><br>
+         For example, the code for Fall 2018 = 2182 And the code for Winter 2019 = 2184 (this is because Winter 2019 comes under the 2018 academic year). </td>
+    </tr>
+    <tr>
+        <td>session</td>
+        <td>string</td>
+        <td>A term can be broken down into separate sessions.  For example, a summer term will commonly have a 1st session (6H1), a second session (6H2) and a full summer session (13W). <br>
+        Possible values (those with * are most common) : <br>
+        10W (10 week) <br>
+        12W (12 week) <br>
+        13W (13 week)* <br>
+        26W (26 week)* <br>
+        2W (2 week) <br>
+        3W1 (3 week first) <br>
+        3W2 ( 3 week second) <br>
+        6H1 (6 and half week first)* <br>
+        6H2 (6 and half week second)* <br>
+        6W (6 week) <br>
+        IDY (Intensive Day CCCE)* <br>
+        NSS (Non-Standard Session)* </td>
+    </tr>
+    <tr>
+        <td>subject</td>
+        <td>string</td>
+        <td>4 character subject code (e.g. ENGL, HIST, COMM). </td>
+    </tr>
+    <tr>
+        <td>catalog</td>
+        <td>string</td>
+        <td>3 or 4 digit catalog number.</td>
+    </tr>
+    <tr>
+        <td>section</td>
+        <td>integer</td>
+        <td>The specific section letter or number of the scheduled class.</td>
+    </tr>
+    <tr>
+        <td>componentCode</td>
+        <td>string</td>
+        <td>3 character code related to the component type (e.g. LEC, TUT, LAB). </td>
+    </tr>
+    <tr>
+        <td>componentDescription</td>
+        <td>string</td>
+        <td>Description of component code (e.g. Lecture, Tutorial, Laboratory).</td>
+    </tr>
+    <tr>
+        <td>classNumber</td>
+        <td>integer</td>
+        <td>A 4 or 5 digit number that is unique to each scheduled section within a term. </td>
+    </tr>
+    <tr>
+        <td>classAssociation</td>
+        <td>integer</td>
+        <td>The class association number links class sections together that are scheduled for the same course within a unique term. <br> <br>For example, if MATH201 has a LEC (Lecture) Section A and a TUT (Tutorial) Section AB and both have class association number 1, that means they are linked together and a student should take TUT Section AB with LEC Section A. <br><br>A class association of ‘9999’ assigned to a class component means it is linked to any of the other classes offered for that course in the term. </td>
+    </tr>
+    <tr>
+        <td>courseTitle</td>
+        <td>string</td>
+        <td>Title of the course </td>
+    </tr>
+    <tr>
+        <td>topicID</td>
+        <td>integer</td>
+        <td>If a course is a topic course (meaning it is the same course ID/subject code and catalog # but can have topics that differ for each offering) it will have a topic ID which is a 1 or 2 digit number. <br><br>Value can be null.</td>
+    </tr>
+    <tr>
+        <td>topicDescription</td>
+        <td>string</td>
+        <td>This is the description of the topic that relates to the above topic ID for the course. </td>
+    </tr>
+    <tr>
+        <td>classStatus</td>
+        <td>string</td>
+        <td>Currently we only show ‘Active’ classes (those available for enrollment). </td>
+    </tr>
+    <tr>
+        <td>locationCode</td>
+        <td>string</td>
+        <td>The CAMPUS at which the class is offered. <br><br>SGW (Sir George Williams – downtown) <br> LOY (Loyola) <br> ONL (Online)<br> PI (Power Institute) </td>
+    </tr>
+    <tr>
+        <td>instructionModeCode</td>
+        <td>string</td>
+        <td>The method of instruction for the class. <br>B (Blended Learning) <br>OL (On-Line) <br>P (In Person)</td>
+    </tr>
+    <tr>
+        <td>instructionModeDescription</td>
+        <td>string</td>
+        <td>The description of the instruction mode code above. </td>
+    </tr>
+    <tr>
+        <td>meetingPatternNumber</td>
+        <td>integer</td>
+        <td>A class can have more than one meeting pattern, if for example, the times or days the class if offered change over the term. </td>
+    </tr>
+    <tr>
+        <td>roomCode</td>
+        <td>string</td>
+        <td>This is the overall code for the room that the class is assigned to.  It comprises the building code and room number. </td>
+    </tr>
+    <tr>
+        <td>buildingCode</td>
+        <td>string</td>
+        <td>The building code the class is assigned to. </td>
+    </tr>
+    <tr>
+        <td>room</td>
+        <td>string</td>
+        <td>The room number that the class is assigned to. </td>
+    </tr>
+    <tr>
+        <td>classStartTime</td>
+        <td>time</td>
+        <td>Class start time.</td>
+    </tr>
+    <tr>
+        <td>classEndTime</td>
+        <td>time</td>
+        <td>Class end time.</td>
+    </tr>
+    <tr>
+        <td>mondays</td>
+        <td>boolean</td>
+        <td>Mondays.</td>
+    </tr>
+    <tr>
+        <td>tuesdays</td>
+        <td>boolean</td>
+        <td>Tuesdays.</td>
+    </tr>
+    <tr>
+        <td>wednesdays</td>
+        <td>boolean</td>
+        <td>Wednesdays.</td>
+    </tr>
+    <tr>
+        <td>thursdays</td>
+        <td>boolean</td>
+        <td>Thursdays.</td>
+    </tr>
+    <tr>
+        <td>fridays</td>
+        <td>boolean</td>
+        <td>Fridays.</td>
+    </tr>
+    <tr>
+        <td>saturdays</td>
+        <td>boolean</td>
+        <td>Saturdays.</td>
+    </tr>
+    <tr>
+        <td>sundays</td>
+        <td>boolean</td>
+        <td>Sundays.</td>
+    </tr>
+    <tr>
+        <td>classStartDate</td>
+        <td>date</td>
+        <td>Date when class starts.</td>
+    </tr>
+    <tr>
+        <td>classEndDate</td>
+        <td>date</td>
+        <td>Date when class ends.</td>
     </tr>
     <tr>
         <td>career</td>
         <td>string</td>
-        <td>Undergraduate (UGRD), Graduate (GRAD) or Continuing Education (CCCE) or Professional Development (PDEV).</td>
+        <td>Level of study. Undergraduate (UGRD), Graduate (GRAD)or Continuing Education (CCCE) or Professional Development (PDEV)</td>
     </tr>
-        <tr>
-        <td>termCode</td>
-        <td></td>
-        <td>4 Digit term code.  This is comprised of the 1st, 3rd and 4th digit of the academic year and ends with one of the following :<br><br>
-1 – Summer <br>
-2 – Fall<br>
-3 – Fall/Winter<br>
-4 – Winter <br>
-5 – Spring (for CCCE career only)<br>
-6 – Summer (for CCCE career only)<br><br>
-For example, the code for Fall 2018 = 2182
-And the code for Winter 2019 = 2184 (this is because Winter 2019 comes under the 2018 academic year).</td>
-    </tr>
-        <tr>
-        <td>termDescription</td>
+    <tr>
+        <td>departmentCode</td>
         <td>string</td>
-        <td>Description of the Term Code (for e.g. Fall 2018).</td>
+        <td>3 to 10 character code for the Department. </td>
     </tr>
-        <tr>
-        <td>sessionCode</td>
+    <tr>
+        <td>departmentDescription</td>
         <td>string</td>
-        <td>A term can be broken down into separate sessions.  For example, a summer term will commonly have a 1st session (6H1), a second session (6H2) and a full summer session (13W).</td>
+        <td>Description of the above Department Code. </td>
     </tr>
-        <tr>
-        <td>sessionDescription</td>
+    <tr>
+        <td>facultyCode</td>
         <td>string</td>
-        <td>Description of the Session Code (for e.g 13 week).</td>
+        <td>2 to 4 character code for the Faculty. </td>
     </tr>
-        <tr>
-        <td>sessionBeginDate</td>
-        <td>date</td>
-        <td>Date session begins.</td>
+    <tr>
+        <td>facultyDescription</td>
+        <td>string</td>
+        <td>Description of the above Faculty Code. </td>
     </tr>
-        <tr>
-        <td>sessionEndDate</td>
-        <td>date</td>
-        <td>Date session ends.</td>
+    <tr>
+        <td>enrollmentCapacity</td>
+        <td>integer</td>
+        <td>The set capacity of the class – how many students can enroll. </td>
+    </tr>
+    <tr>
+        <td>currentEnrollment</td>
+        <td>integer</td>
+        <td>Currently how many students are enrolled.</td>
+    </tr>
+    <tr>
+        <td>waitlistCapacity</td>
+        <td>integer</td>
+        <td>How many students can be on the waitlist.</td>
+    </tr>
+    <tr>
+        <td>currentWaitlistTotal</td>
+        <td>integer</td>
+        <td>Currently how many students are on the waitlist.</td>
+    </tr>
+    <tr>
+        <td>hasSeatReserved</td>
+        <td>boolean</td>
+        <td>Does this class have seats reserved for students with a certain criteria.</td>
     </tr>
 </table>
 
@@ -102,22 +289,48 @@ And the code for Winter 2019 = 2184 (this is because Winter 2019 comes under the
 ```JSON
 [
     {
-        "career": "GRAD",
-        "termCode": "2141",
-        "termDescription": "Summer 2014",
-        "sessionCode": "13W",
-        "sessionDescription": "13 week",
-        "sessionBeginDate": "07/05/2014",
-        "sessionEndDate": "19/08/2014"
-    },
-    {
-        "career": "GRAD",
-        "termCode": "2142",
-        "termDescription": "Fall 2014",
-        "sessionCode": "13W",
-        "sessionDescription": "13 week",
-        "sessionBeginDate": "02/09/2014",
-        "sessionEndDate": "01/12/2014"
+    "courseID": "002683",
+    "termCode": "2224",
+    "session": "13W",
+    "subject": "BIOL",
+    "catalog": "321",
+    "section": "01",
+    "componentCode": "LEC",
+    "componentDescription": "Lecture",
+    "classNumber": "5791",
+    "classAssociation": "1",
+    "courseTitle": "EVOLUTION",
+    "topicID": "",
+    "topicDescription": "",
+    "classStatus": "Active",
+    "locationCode": "LOY",
+    "instructionModeCode": "P",
+    "instructionModeDescription": "In Person",
+    "meetingPatternNumber": "1",
+    "roomCode": "HC157",
+    "buildingCode": "HC",
+    "room": "157",
+    "classStartTime": "10.15.00",
+    "classEndTime": "11.30.00",
+    "modays": "N",
+    "tuesdays": "Y",
+    "wednesdays": "N",
+    "thursdays": "Y",
+    "fridays": "N",
+    "saturdays": "N",
+    "sundays": "N",
+    "classStartDate": "09/01/2023",
+    "classEndDate": "17/04/2023",
+    "career": "Undergraduate",
+    "departmentCode": "BIOLOGY",
+    "departmentDescription": "Biology",
+    "facultyCode": "AS",
+    "facultyDescription": "Faculty of Arts & Science",
+    "enrollmentCapacity": "102",
+    "currentEnrollment": "102",
+    "waitlistCapacity": "20",
+    "currentWaitlistTotal": "7",
+    "hasSeatReserved": "Y"
     },
     ...
 ]


### PR DESCRIPTION
Updated `README.md` to include the new endpoint implemented in issue #16 allowing for the filtering of the course schedule by term code.

Includes a new file named `scheduleTerm.md` detailing the endpoint in the style of the rest of the documentation.